### PR TITLE
remove calls of undefined functions

### DIFF
--- a/code-blocks.lisp
+++ b/code-blocks.lisp
@@ -105,9 +105,9 @@
         (format stream "</code></pre>")))))
 
 (defmethod print-md-tagged-element ((tag (eql 'code-block)) stream rest)
-  (3bmd::ensure-paragraph stream)
+  (3bmd::ensure-block stream)
   (format stream "```~a~%~a~%```" (getf rest :lang) (getf rest :content))
-  (3bmd::end-paragraph stream))
+  (3bmd::end-block stream))
 
 
 ;;; fixme: add hooks to do this properly, so multiple extensions don't conflict


### PR DESCRIPTION
Here's a patch for issue #14. 

By the way, thanks for the library. I am using it to chop markdown files into bite size chunks for printing as an interactive tutorial in https://github.com/m-n/rundown.
