### PR TITLE
Add support for coloring using pygments.

### DIFF
--- a/3bmd-ext-code-blocks.asd
+++ b/3bmd-ext-code-blocks.asd
@@ -1,5 +1,5 @@
 (defsystem 3bmd-ext-code-blocks
-  :description "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize"
-  :depends-on (3bmd colorize alexandria)
+  :description "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize or pygments"
+  :depends-on (3bmd colorize alexandria inferior-shell cl-ppcre)
   :serial t
   :components ((:file "code-blocks")))

--- a/code-blocks.lisp
+++ b/code-blocks.lisp
@@ -139,7 +139,7 @@
 ;-------------------------------------------------------------------------------
 ;;; extra parameters to be passed to the renderer
 (defrule code-block-params (and "|"
-                                (* (and (! 3bmd-grammar:newline) character)))
+                                (* (and (! 3bmd-grammar::newline) character)))
   (:destructure (vert params)
                 (declare (ignore vert))
                 (when params (text params))))


### PR DESCRIPTION
This functionality requires the pygmentize script to be present on the system in a location pointed to by shell's `PATH` variable.

The user may choose which renderer to use by setting the `*renderer*` parameter to either `:colorize` (the default) or `:pygments`.

`*render-code-spans*` parameter has been added to determine whether the inline code spans should be colorized according to the language lexing rules specified by the `*render-code-spans-lang*` parameter. These two replace the `*colorize-code-spans-as*` parameter, because both renderers
can colorize the inline code spans and pytments does a semi-decent thing even if no lexing rules are speciffied.

Additionally, support for specifying renderer options has been added. This allows the user to fine-tune the output. Ie.

'''c++|linenos=inline

'''
