### PR TITLE
Trim the trailing newline in pygments output for inline code spans

### DIFF
--- a/code-blocks.lisp
+++ b/code-blocks.lisp
@@ -150,7 +150,8 @@
         (*pygments-args* *pygments-span-args*))
     (render-code-block renderer s *render-code-spans-lang* nil code)
     (format stream "<span class=\"highlight\"><code>~a</code></span>"
-            (get-output-stream-string s))))
+            (string-right-trim '(#\Newline)
+                               (get-output-stream-string s)))))
 
 ;-------------------------------------------------------------------------------
 ; Parsing


### PR DESCRIPTION
Pygments seems to always insert a new line at the end of the output which, in conjunction with the `<code>` tag, results in unintended right padding in the rendered page.