### PR TITLE
Add support for math markup using libraries like MathJax

### DIFF
--- a/3bmd-ext-math.asd
+++ b/3bmd-ext-math.asd
@@ -1,0 +1,9 @@
+(in-package #:asdf-user)
+
+(defsystem 3bmd-ext-math
+  :description "An extension for 3bmd for handling math markup"
+  :depends-on (3bmd esrap)
+  :serial t
+  :license "MIT"
+  :author "Lukasz Janyst <lukasz@jany.st>"
+  :components ((:file "math")))

--- a/README.md
+++ b/README.md
@@ -100,3 +100,9 @@ especially, without heading:
 
         !yt[nbY-meOL57I]
         !yt[nbY-meOL57I|width=20,allowfullscreen]"
+
+* Loading `3bmd-math.asd` adds support for math markup with libraries like MathJax. If `3bmd-math:*math*` is non-`NIL` while parsing, the shorthand syntax `$$ latex markup $$` can be be used. For example:
+
+        $$
+        \frac{\partial E}{\partial y} = \frac{\partial }{\partial y} \frac{1}{n}\sum_{i=1}^{n} (y_i - a_i)^2
+        $$

--- a/math.lisp
+++ b/math.lisp
@@ -1,0 +1,53 @@
+;-------------------------------------------------------------------------------
+; Support math markup using libraries like MathJax
+; Author: Lukasz Janyst <lukasz@jany.st>
+;
+; Works both with inline math:
+;
+; Begining of the paragraph $$ \sum_{i=0}^{10} (u_{i} x_{i})^2 $$ blah blah
+;
+; and with blocks:
+;
+; $$
+; \sum_{i=0}^{10} (u_{i} x_{i})^2
+; $$
+;-------------------------------------------------------------------------------
+
+(defpackage #:3bmd-math
+  (:use #:cl #:esrap #:3bmd-ext)
+  (:export #:*math*))
+
+(in-package #:3bmd-math)
+
+(defrule math-content (* (and (! "$$") character))
+  (:text t))
+
+(define-extension-inline *math* math-inline
+    (and "$$" math-content "$$")
+  (:destructure (s c e)
+                (declare (ignore s e))
+                (list :math-inline c)))
+
+(define-extension-block *math* math-block
+    (and "$$" math-content "$$")
+    (:destructure (s c e)
+                (declare (ignore s e))
+                (list :math-block c)))
+
+(defmethod print-tagged-element ((tag (eql :math-inline)) stream rest)
+  (format stream "\\(~a\\)" (car rest)))
+
+(defmethod print-tagged-element ((tag (eql :math-block)) stream rest)
+  (format stream "\\[~a\\]" (car rest)))
+
+#++
+(let ((3bmd-math:*math* t))
+  (esrap:parse 'inline "$$ \sum_{i=0}^{10} (u_{i} x_{i})^2 $$"))
+
+#++(let ((3bmd-math:*math* t))
+  (with-output-to-string (s)
+    (3bmd:parse-string-and-print-to-stream "test $$ \sum_{i=0}^{10} (u_{i} x_{i})^2 $$ test" s)))
+
+#++(let ((3bmd-math:*math* t))
+  (with-output-to-string (s)
+    (3bmd:parse-string-and-print-to-stream "$$ \sum_{i=0}^{10} (u_{i} x_{i})^2 $$" s)))


### PR DESCRIPTION
It has worked so far largely by accident. This is because MathJax recognizes the "$$" blocks by default. This approach, however, does not support inline math spans and breaks when you're unlucky enough to type something like:

```
$$
w_{51} x_{51}
$$
```
because it ends up being:

```
<p>$$
w<em>{51} x</em>{51}
$$</p>
```

This extensions solves this kind of problems and add support inline math.