### PR TITLE
Add persistent pygments rendering process

### DIFF
--- a/3bmd-ext-code-blocks.asd
+++ b/3bmd-ext-code-blocks.asd
@@ -1,5 +1,6 @@
 (defsystem 3bmd-ext-code-blocks
   :description "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize or pygments"
-  :depends-on (3bmd colorize alexandria #-asdf3 :uiop)
+  :depends-on (3bmd colorize alexandria split-sequence #-asdf3 :uiop)
   :serial t
-  :components ((:file "code-blocks")))
+  :components ((:file "code-blocks")
+               (:static-file "pygmentize.py")))

--- a/pygmentize.py
+++ b/pygmentize.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 #-------------------------------------------------------------------------------
 # Author: Lukasz Janyst <lukasz@jany.st>
 #-------------------------------------------------------------------------------
@@ -9,6 +7,7 @@ import sys
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.formatters import HtmlFormatter
+from pygments.util import ClassNotFound
 
 input  = io.TextIOWrapper(sys.stdin.buffer,  encoding='utf-8')
 output = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
@@ -26,34 +25,73 @@ while True:
     command = command.split('|')
     if command[0] == 'exit':
         sys.exit(0)
+
+    if command[0] != 'pygmentize':
+        eprint('Unknown command:', command[0])
+        continue
+
     if len(command) < 3:
         eprint('Invalid input')
         sys.exit(1)
 
+    try:
+        size = int(command[1])
+    except ValueError:
+        eprint('Second parameter needs to be an integer, got:', command[1])
+        sys.exit(1)
+
     code = ''
-    size = int(command[1])
     while size > 0:
         data = input.read(size)
         ldata = len(data)
         size -= ldata
         code += data
 
+    try:
+        lexer = get_lexer_by_name(command[2], stripall=True)
+    except ClassNotFound:
+        eprint('Cannot find lexer for {}, using "text" instead'.format(command[2]))
+        lexer = get_lexer_by_name('text', stripall=True)
+
     opts = {}
-    opts['noclobber_cssfile'] = True
-    forbidden = ['cssfile']
+    params = {
+        'nowrap': bool,
+        'style': str,
+        'noclasses': bool,
+        'classprefix': str,
+        'cssclass': str,
+        'cssstyles': str,
+        'prestyles': str,
+        'linenos': str,
+        'linenostart': int,
+        'linenostep': int,
+        'linenoseparator': str,
+        'lineanchors': str,
+        'linespans': str,
+        'anchorlinenos': bool
+        }
     argmap = {'true': True, 'false': False}
 
     if len(command) == 4:
         for opt in command[3].split(','):
             opt = opt.split('=')
-            if opt[0] in forbidden:
-                eprint("ignoring:", opt[0])
+            if opt[0] not in params.keys():
+                eprint('ignoring:', opt[0])
+                continue
             if len(opt) >= 2:
-                opts[opt[0]] = argmap.get(opt[1].lower(), opt[1])
+                if params[opt[0]] == bool:
+                    opts[opt[0]] = argmap.get(opt[1].lower(), True)
+                elif params[opt[0]] == int:
+                    try:
+                        opts[opt[0]] = int(opt[1])
+                    except ValueError:
+                        eprint('Ignoring {}, expected an integer, got {}' \
+                               .format(opt[0], opt[1]))
+                else:
+                    opts[opt[0]] = opt[1]
             else:
                 opts[opt[0]] = True
 
-    lexer = get_lexer_by_name(command[2], stripall = True)
     formatter = HtmlFormatter(**opts)
     highlighted = highlight(code, lexer, formatter)
     output.write('colorized|{}\n'.format(len(highlighted)))

--- a/pygmentize.py
+++ b/pygmentize.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+#-------------------------------------------------------------------------------
+# Author: Lukasz Janyst <lukasz@jany.st>
+#-------------------------------------------------------------------------------
+
+import io
+import sys
+from pygments import highlight
+from pygments.lexers import get_lexer_by_name
+from pygments.formatters import HtmlFormatter
+
+input  = io.TextIOWrapper(sys.stdin.buffer,  encoding='utf-8')
+output = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+while True:
+    command = input.readline().strip();
+    eprint(command)
+    if len(command) == 0:
+        eprint("aborted")
+        sys.exit(1)
+
+    command = command.split('|')
+    if command[0] == 'exit':
+        sys.exit(0)
+    if len(command) < 3:
+        eprint('Invalid input')
+        sys.exit(1)
+
+    code = ''
+    size = int(command[1])
+    while size > 0:
+        data = input.read(size)
+        ldata = len(data)
+        size -= ldata
+        code += data
+
+    opts = {}
+    opts['noclobber_cssfile'] = True
+    forbidden = ['cssfile']
+    argmap = {'true': True, 'false': False}
+
+    if len(command) == 4:
+        for opt in command[3].split(','):
+            opt = opt.split('=')
+            if opt[0] in forbidden:
+                eprint("ignoring:", opt[0])
+            if len(opt) >= 2:
+                opts[opt[0]] = argmap.get(opt[1].lower(), opt[1])
+            else:
+                opts[opt[0]] = True
+
+    lexer = get_lexer_by_name(command[2], stripall = True)
+    formatter = HtmlFormatter(**opts)
+    highlighted = highlight(code, lexer, formatter)
+    output.write('colorized|{}\n'.format(len(highlighted)))
+    output.write(highlighted)
+    output.flush()


### PR DESCRIPTION
Spawning a pygmentize process every time a code block needs to be processed takes up a lot of time. It may take up to minutes to process a small blog. It is far more efficient to spawn one colorizing process
and keep it running. One can then send code and receive colorized HTML via standard IO. This is the approach that this patch enables while keeping the old behavior as a default for the sake of backwards
compatibility.


Below are some of my stats. I was able to get down from well over a minute to 2.8 seconds for my blog.

```
]==> time ./coleslaw-old.x /path/to/blog/
./coleslaw-old.x /path/to/blog/  66.40s user 6.19s system 98% cpu 1:13.55 total
]==> time ./coleslaw-new-no-renderer.x /path/to/blog/ 
./coleslaw-new-no-renderer.x /path/to/blog/  65.50s user 6.03s system 98% cpu 1:12.53 total
]==> time ./coleslaw-new-renderer.x /path/to/blog/ 
./coleslaw-new-renderer.x /path/to/blog/  2.78s user 0.27s system 106% cpu 2.849 total
```