### PR TITLE
Add an ID tag to headings to allow anchor links to sections.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,8 @@
            #:parse-and-print-to-stream
            #:print-doc-to-stream
            #:*smart-quotes*
-           ))
+           #:*url-fragment-chars*
+           #:*generate-header-ids*))
 
 
 

--- a/package.lisp
+++ b/package.lisp
@@ -32,7 +32,7 @@
            #:parse-and-print-to-stream
            #:print-doc-to-stream
            #:*smart-quotes*
-           #:*url-fragment-chars*
+           #:*allowed-id-chars*
            #:*generate-header-ids*))
 
 

--- a/printer.lisp
+++ b/printer.lisp
@@ -61,10 +61,6 @@
   "A string of characters that are allowed to appear within an element ID string.")
 
 (defun html-content-id (html)
-  "Computes an applicable element ID from the given HTML string.
-
-If no ID should be used to identify the given content, NIL can be
-returned instead."
   (with-output-to-string (out)
     (loop with state = :text
           for c across html
@@ -81,7 +77,7 @@ returned instead."
                   (setf state :text)))))))
 
 (defvar *generate-header-ids* NIL
-  "Whether ID strings should be generated for header elements.")
+  "Whether ID attributes should be generated for header elements.")
 
 ;; todo: minimize extra newlines...
 (defmethod print-tagged-element ((tag (eql :heading)) stream rest)

--- a/printer.lisp
+++ b/printer.lisp
@@ -57,7 +57,7 @@
     (with-output-to-string (s)
       (print-pre-escaped string s))))
 
-(defvar *url-fragment-chars* "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890@$&'()*+.,;:?!=-_/"
+(defvar *allowed-id-chars* "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890@$&'()*+.,;:?!=-_/"
   "A string of characters that are allowed to appear within an element ID string.")
 
 (defun html-content-id (html)
@@ -70,7 +70,7 @@
                        (setf state :tag))
                       ((eql c #\ )
                        (write-char #\_ out))
-                      ((find c *url-fragment-chars*)
+                      ((find c *allowed-id-chars*)
                        (write-char (char-downcase c) out))))
                (:tag
                 (when (eql c #\>)


### PR DESCRIPTION
Currently documents produced by 3bmd are a bit of a pain as you cannot link to a specific section within it. This PR adds an automatically generated id attribute to headings based on the heading's text. This in turn allows cross-referencing and linking to each section using URL fragments.

The id is generated as follows from the heading text:

1. If the character is a space, use an underscore instead.
2. If the character is one of `ABCDEFGHIJKLMNOPQRSTUVWXYZ` use it downcased.
3. If the character is one of `abcdefghijklmnopqrstuvwxyz01234567890@$&'()*+.,;:?!=-_/` use it verbatim.
4. Otherwise discard the character.

The set of used characters is determined according to the characters allowed in an URL's fragment part without percent-encoding.