### PR TITLE
Patch for CLISP.

### DIFF
--- a/extensions.lisp
+++ b/extensions.lisp
@@ -30,6 +30,8 @@
                          return 0
                          minimize (or (position i list) len))
                       len)))
+        (setf min (or min 0)
+              max (or max 0))
         (when (< max min)
           (error "can't add rule to expression, conflicting before=~s(~s) after=~s(\
 ~s)" before max after min))


### PR DESCRIPTION
[CLHS says](http://www.lispworks.com/documentation/HyperSpec/Body/06_ac.htm)

> If the maximize or minimize clause is never executed, the accumulated value is unspecified.

CLISP returns NIL.