### PR TITLE
feat: add support for syntax highlighting via Chroma

### DIFF
--- a/3bmd-ext-code-blocks.asd
+++ b/3bmd-ext-code-blocks.asd
@@ -1,5 +1,5 @@
 (defsystem 3bmd-ext-code-blocks
-  :description "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize or pygments"
+  :description "extension to 3bmd implementing github style ``` delimited code blocks, with support for syntax highlighting using colorize, pygments, or chroma"
   :depends-on (3bmd colorize alexandria split-sequence #-asdf3 :uiop)
   :serial t
   :components ((:file "code-blocks")

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ todo:
     Some attempt has been made to avoid interpretation of the options by the shell when calling `pygmentize`, but you should probably audit the code and test the interaction with the implementation of `uiop:run-program` on your implementation of choice before using it on untrusted input. Pygments html formatter creates arbitrary files when passed `-Ofull,cssfile=filename`, so parameters with the substring `cssfile` are ignored (`noclobber_cssfile=True` is also set by default, but that only prevents overwriting, not creation). Users with untrusted input may want to audit that as well to make sure there are no other dangerous options or ways to get around the exact substring check.
 
 
+    Can optionally use [`Chroma`](https://github.com/alecthomas/chroma) instead of `colorize` or `Pygments` by setting `3bmd-code-blocks:*renderer*` to  `:chroma`. Change the embedded theme of the `:chroma` code block via `3bmd-code-blocks:*chroma-style*`. The various styles for Chroma can be viewed via `chroma --list`.
+
 * Loading `3bmd-ext-definition-lists.asd` adds support for parsing PHP Markdown Extra style definition lists
      If `3bmd-definition-lists:*definition-lists*` is non-`NIL` while parsing, the following definition list will be recognized (see <http://michelf.ca/projects/php-markdown/extra/#def-list>):
 


### PR DESCRIPTION
Chroma[1] is a syntax highlighting tool that is the engine behind
syntax highlighting in Hugo[2]. This commit adds support via the `:chroma`
renderer symbol and also adds a new `*chroma-style*` string variable to change the
appearance of the rendered code block.

The benefits of Chroma is that it's _very_ fast and it's distributed
as a static compiled binary meaning it should be easier to use in various environments.

[1]: https://github.com/alecthomas/chroma
[2]: https://gohugo.io/