### PR TITLE
disable failing test PARSE-LIST-WITH-CARRIAGE-RETURN

### DIFF
--- a/tests/grammar/blocks/bullet-list.lisp
+++ b/tests/grammar/blocks/bullet-list.lisp
@@ -89,6 +89,10 @@
               (:BULLET-LIST (:LIST-ITEM (:PLAIN "Bar")))))
 
 
+;;; CLISP treats the return character as a line ending regardless of
+;;; the platform
+;;; (https://clisp.sourceforge.io/impnotes/clhs-newline.html).
+#-(or clisp windows)
 (def-grammar-test parse-list-with-carriage-return
   :text "* xy
 


### PR DESCRIPTION
... on platforms, Lisps where it doesn't make sense.