### PR TITLE
do not escape characters in :LINKs when printing to :MARKDOWN

### DIFF
--- a/markdown-printer.lisp
+++ b/markdown-printer.lisp
@@ -118,7 +118,8 @@
 
 (defmethod print-md-tagged-element ((tag (eql :link)) stream rest)
   (format stream "<")
-  (dolist (a rest) (print-md-element a stream))
+  (let ((*md-inline-chars-to-escape* ""))
+    (dolist (a rest) (print-md-element a stream)))
   (format stream ">"))
 
 (defmethod print-md-tagged-element ((tag (eql :mailto)) stream rest)

--- a/tests/printing/inline.lisp
+++ b/tests/printing/inline.lisp
@@ -158,3 +158,8 @@
 "
   :expected "\\inlinelatexormathjax{arg}
 ")
+
+(def-print-test do-not-escape-md-chars-in-urls
+  :format :markdown
+  :text "<http://a/?forum_id=*_`&[]>"
+  :expected "<http://a/?forum_id=*_`&[]>")


### PR DESCRIPTION
Everything that had to be escaped must have been already URL encoded for it to be parsed.

This improves Markdown parse-print consistency.