### PR TITLE
make STRINGs start with alphanumeric chars

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -469,7 +469,10 @@
 
 (defrule maybe-alphanumeric (& alphanumeric)
   (:constant ""))
-(defrule string (and normal-char (* (or normal-char (and (+ #\_) maybe-alphanumeric))))
+(defrule string (or (and alphanumeric (* (or normal-char
+                                             (and (+ #\_) maybe-alphanumeric))))
+                    ;; This could be (+ NORMAL-CHAR), but that's a bit slower.
+                    normal-char)
   (:text t))
 
 (defrule maybe-space-char (& space-char)

--- a/tests/grammar/blocks/heading.lisp
+++ b/tests/grammar/blocks/heading.lisp
@@ -71,7 +71,7 @@ World!
                (:LIST-ITEM (:PLAIN "First" " " "line")))
               (:PLAIN "  " "The" " " "header" "
 "
-               "  " "==========")))
+               "  " "=" "=" "=" "=" "=" "=" "=" "=" "=" "=")))
 
 (def-grammar-test atx-heading-in-a-list ;; bug 35
   ;;; marked bug as invalid, since original markdown is inconsistent

--- a/tests/grammar/inlines/emph.lisp
+++ b/tests/grammar/inlines/emph.lisp
@@ -103,3 +103,93 @@
   :expected '((:BULLET-LIST
                (:LIST-ITEM (:PLAIN "First" " " "line")))
               (:PARAGRAPH (:EMPH "Some" " " "text"))))
+
+(def-grammar-test emph-in-parens
+  :rule 3bmd-grammar::doc
+  :text "(_x_)"
+  :expected '((:PLAIN "(" (:EMPH "x") ")")))
+
+(def-grammar-test emph-in-braces
+  :rule 3bmd-grammar::doc
+  :text "{_x_}"
+  :expected '((:PLAIN "{" (:EMPH "x") "}")))
+
+(def-grammar-test emph-in-double-quotes
+  :rule 3bmd-grammar::doc
+  :text "\"_x_\""
+  :expected '((:PLAIN "\"" (:EMPH "x") "\"")))
+
+(def-grammar-test emph-in-single-quotes
+  :rule 3bmd-grammar::doc
+  :text "'_x_'"
+  :expected '((:PLAIN "'" (:EMPH "x") "'")))
+
+(def-grammar-test emph-after-comma
+  :rule 3bmd-grammar::doc
+  :text ",_x_"
+  :expected '((:PLAIN "," (:EMPH "x"))))
+
+(def-grammar-test emph-after-period
+  :rule 3bmd-grammar::doc
+  :text "._x_"
+  :expected '((:PLAIN "." (:EMPH "x"))))
+
+(def-grammar-test emph-after-semicolon
+  :rule 3bmd-grammar::doc
+  :text ";_x_"
+  :expected '((:PLAIN ";" (:EMPH "x"))))
+
+(def-grammar-test emph-after-colon
+  :rule 3bmd-grammar::doc
+  :text ":_x_"
+  :expected '((:PLAIN ":" (:EMPH "x"))))
+
+(def-grammar-test emph-after-question-mark
+  :rule 3bmd-grammar::doc
+  :text "?_x_"
+  :expected '((:PLAIN "?" (:EMPH "x"))))
+
+(def-grammar-test emph-after-equal
+  :rule 3bmd-grammar::doc
+  :text "=_x_"
+  :expected '((:PLAIN "=" (:EMPH "x"))))
+
+(def-grammar-test emph-after-plus
+  :rule 3bmd-grammar::doc
+  :text "+_x_"
+  :expected '((:PLAIN "+" (:EMPH "x"))))
+
+(def-grammar-test emph-after-minus
+  :rule 3bmd-grammar::doc
+  :text "-_x_"
+  :expected '((:PLAIN "-" (:EMPH "x"))))
+
+(def-grammar-test emph-after-caret
+  :rule 3bmd-grammar::doc
+  :text "^_x_"
+  :expected '((:PLAIN "^" (:EMPH "x"))))
+
+(def-grammar-test emph-after-slash
+  :rule 3bmd-grammar::doc
+  :text "/_x_"
+  :expected '((:PLAIN "/" (:EMPH "x"))))
+
+(def-grammar-test emph-after-bar
+  :rule 3bmd-grammar::doc
+  :text "|_x_"
+  :expected '((:PLAIN "|" (:EMPH "x"))))
+
+(def-grammar-test emph-after-percent
+  :rule 3bmd-grammar::doc
+  :text "%_x_"
+  :expected '((:PLAIN "%" (:EMPH "x"))))
+
+(def-grammar-test emph-after-dollar
+  :rule 3bmd-grammar::doc
+  :text "$_x_"
+  :expected '((:PLAIN "$" (:EMPH "x"))))
+
+(def-grammar-test emph-after-at
+  :rule 3bmd-grammar::doc
+  :text "@_x_"
+  :expected '((:PLAIN "@" (:EMPH "x"))))

--- a/tests/grammar/inlines/link.lisp
+++ b/tests/grammar/inlines/link.lisp
@@ -140,5 +140,5 @@ x"
   :expected '((:PARAGRAPH
                (:REFERENCE-LINK :LABEL ("link") :TAIL NIL))
               (:PLAIN (:REFERENCE-LINK :LABEL ("link") :TAIL NIL)
-               ":" " " "http://example.com/" " " "\"title\"" " "
+               ":" " " "http://example.com/" " " "\"" "title\"" " "
                "junk")))

--- a/tests/grammar/inlines/string.lisp
+++ b/tests/grammar/inlines/string.lisp
@@ -16,8 +16,8 @@
 (def-grammar-test string-test-3
   :rule 3bmd-grammar::string
   :text "@a_symbol@ string with spaces."
-  :expected "@a_symbol@"
-  :remaining-text " string with spaces.")
+  :expected "@"
+  :remaining-text "a_symbol@ string with spaces.")
 
 (def-grammar-test string-test-4
   :rule 3bmd-grammar::string

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -95,8 +95,9 @@
                ,@(if warn
                      ;; just supporting 1 warning for now
                      `((is (= 1 (length signalled-warnings)))
-                       (let ((signalled-warning (format nil "~a"
-                                                        (car signalled-warnings))))
+                       (let* ((*print-right-margin* most-positive-fixnum)
+                              (signalled-warning
+                                (format nil "~a" (car signalled-warnings))))
                          (is (string= signalled-warning ,warn))))
 
                      `((is (not signalled-warnings))))


### PR DESCRIPTION
... or consist of a single non-alphanumeric character.

For example, this allows parsing

    (_x_)

as emphasis.